### PR TITLE
Fix final label when timer ends

### DIFF
--- a/timer_date/ContentView.swift
+++ b/timer_date/ContentView.swift
@@ -96,8 +96,14 @@ struct ContentView: View {
 
     // MARK: - 表示用プロパティ
     private var remainingSecondsLabel: String {
-        guard let sec = remainingSeconds else { return "--:--" }
-        return String(format: "%02d:%02d", sec / 60, sec % 60)
+        if let sec = remainingSeconds {
+            return String(format: "%02d:%02d", sec / 60, sec % 60)
+        } else if totalSeconds > 0 {
+            // タイマー終了後は 00:00 を表示する
+            return "00:00"
+        } else {
+            return "--:--"
+        }
     }
 
     private var progress: Double {


### PR DESCRIPTION
## Summary
- update timer label logic so the view shows `00:00` once a countdown completes

## Testing
- `swiftc -parse timer_date/ContentView.swift timer_date/WindowLevelHelper.swift timer_date/timer_dateApp.swift`

------
https://chatgpt.com/codex/tasks/task_e_684291fc14d4832bacfea3527120a87e